### PR TITLE
feat: migrate plugin to OpenAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 <h4 align="right">
-  <strong>简体中文</strong> | <a href="https://github.com/jtsang4/bob-plugin-claude-translator/blob/main/docs/README_EN.md">English</a>
+  <strong>简体中文</strong> | <a href="https://github.com/jtsang4/bob-plugin-openaiapi/blob/main/docs/README_EN.md">English</a>
 </h4>
 
 <div>
-  <h1 align="center">Claude Translator Bob Plugin</h1>
+  <h1 align="center">OpenAI Translator Bob Plugin</h1>
   <p align="center">
-    <a href="https://github.com/jtsang4/bob-plugin-claude-translator/releases" target="_blank">
-        <img src="https://github.com/jtsang4/bob-plugin-claude-translator/actions/workflows/release.yaml/badge.svg" alt="release">
+    <a href="https://github.com/jtsang4/bob-plugin-openaiapi/releases" target="_blank">
+        <img src="https://github.com/jtsang4/bob-plugin-openaiapi/actions/workflows/release.yaml/badge.svg" alt="release">
     </a>
-    <a href="https://github.com/jtsang4/bob-plugin-claude-translator/releases">
-        <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/jtsang4/bob-plugin-claude-translator?style=flat">
+    <a href="https://github.com/jtsang4/bob-plugin-openaiapi/releases">
+        <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/jtsang4/bob-plugin-openaiapi?style=flat">
     </a>
-    <a href="https://github.com/jtsang4/bob-plugin-claude-translator/releases">
-        <img alt="GitHub Repo stars" src="https://img.shields.io/badge/claude-bob-orange?style=flat">
+    <a href="https://github.com/jtsang4/bob-plugin-openaiapi/releases">
+        <img alt="GitHub Repo stars" src="https://img.shields.io/badge/openai-bob-orange?style=flat">
     </a>
-    <a href="https://github.com/jtsang4/bob-plugin-claude-translator/releases">
+    <a href="https://github.com/jtsang4/bob-plugin-openaiapi/releases">
         <img alt="GitHub Repo stars" src="https://img.shields.io/badge/langurage-JavaScript-brightgreen?style=flat&color=blue">
     </a>
   </p>
@@ -22,34 +22,34 @@
 
 ## 简介
 
-基于 [Anthropic Complete API](https://console.anthropic.com/docs/api/reference) 实现的 [Bob](https://bobtranslate.com/) 插件。拥有翻译、润色的功能。
+基于 [OpenAI API](https://platform.openai.com/docs/api-reference/introduction) 实现的 [Bob](https://bobtranslate.com/) 插件。拥有翻译、润色的功能，并支持自定义 Base URL、模型和提示词。
 
 ### 润色功能
 
-支持使用 Claude API 对句子进行润色和语法修改，只需要把目标语言设置为与源语言一样即可。
+支持使用 OpenAI API 对句子进行润色和语法修改，只需要把目标语言设置为与源语言一样即可。
 
 ### 语言模型
 
-[官网模型对比](https://docs.anthropic.com/en/docs/about-claude/models#model-comparison)
-* `Claude 3 Haiku` (默认使用): 最快最紧凑的型号,可实现近乎即时的响应
-* `Claude 3 Sonnet`: 智能和速度的平衡
-* `Claude 3 Opus`: 用于高度复杂任务的强大模型
-* `Claude 3.5 Sonnet`: 最智能的模型
+[模型简介](https://platform.openai.com/docs/models)
+* `GPT-4o mini` (默认使用): 速度与成本最优的多用途模型
+* `GPT-4o`: 更强大的旗舰模型
+* `GPT-4.1 / GPT-4.1 mini`: 最新一代的多模态模型
+* `o3-mini`: 强大的推理模型
 
 ## 使用方法
 
 1. 安装 [Bob](https://bobtranslate.com/guide/#%E5%AE%89%E8%A3%85) (版本 >= 0.50)，一款 macOS 平台的翻译和 OCR 软件
 
-2. 下载此插件: [claude-translator.bobplugin](https://github.com/jtsang4/bob-plugin-claude-translator/releases/latest)
+2. 下载此插件: [openai-translator.bobplugin](https://github.com/jtsang4/bob-plugin-openaiapi/releases/latest)
 
 3. 安装此插件
 
-4. 去 [Claude](https://console.anthropic.com/account/keys) 获取你的 API KEY
+4. 去 [OpenAI](https://platform.openai.com/api-keys) 获取你的 API KEY
 
-5. 把 API KEY 填入 Bob 偏好设置 > 服务 > 此插件配置界面的 API KEY 的输入框中
+5. 把 API KEY 填入 Bob 偏好设置 > 服务 > 此插件配置界面的 API KEY 的输入框中，可配置多个 Key、Base URL、模型以及自定义提示词
 
 6. (可选) 安装 [PopClip](https://bobtranslate.com/guide/integration/popclip.html) 实现划词后鼠标附近出现悬浮图标
 
 ## 感谢
 
-本仓库是在 [yetone](https://github.com/yetone) 优秀的 [bob-plugin-openai-translator](https://github.com/yetone/bob-plugin-openai-translator) 源码基础上对 Claude API 所做的适配，感谢原作者的卓越贡献。
+本仓库是在 [yetone](https://github.com/yetone) 优秀的 [bob-plugin-openai-translator](https://github.com/yetone/bob-plugin-openai-translator) 源码基础上的再次适配，感谢原作者的卓越贡献。

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -1,20 +1,20 @@
 <h4 align="right">
-  <a href="https://github.com/jtsang4/bob-plugin-claude-translator/blob/main/README.md">简体中文</a> | <strong>English</strong>
+  <a href="https://github.com/jtsang4/bob-plugin-openaiapi/blob/main/README.md">简体中文</a> | <strong>English</strong>
 </h4>
 
 <div>
-  <h1 align="center">Claude Translator Bob Plugin</h1>
+  <h1 align="center">OpenAI Translator Bob Plugin</h1>
   <p align="center">
-    <a href="https://github.com/jtsang4/bob-plugin-claude-translator/releases" target="_blank">
-        <img src="https://github.com/jtsang4/bob-plugin-claude-translator/actions/workflows/release.yaml/badge.svg" alt="release">
+    <a href="https://github.com/jtsang4/bob-plugin-openaiapi/releases" target="_blank">
+        <img src="https://github.com/jtsang4/bob-plugin-openaiapi/actions/workflows/release.yaml/badge.svg" alt="release">
     </a>
-    <a href="https://github.com/jtsang4/bob-plugin-claude-translator/releases">
-        <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/jtsang4/bob-plugin-claude-translator?style=flat">
+    <a href="https://github.com/jtsang4/bob-plugin-openaiapi/releases">
+        <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/jtsang4/bob-plugin-openaiapi?style=flat">
     </a>
-    <a href="https://github.com/jtsang4/bob-plugin-claude-translator/releases">
-        <img alt="GitHub Repo stars" src="https://img.shields.io/badge/claude-bob-orange?style=flat">
+    <a href="https://github.com/jtsang4/bob-plugin-openaiapi/releases">
+        <img alt="GitHub Repo stars" src="https://img.shields.io/badge/openai-bob-orange?style=flat">
     </a>
-    <a href="https://github.com/jtsang4/bob-plugin-claude-translator/releases">
+    <a href="https://github.com/jtsang4/bob-plugin-openaiapi/releases">
         <img alt="GitHub Repo stars" src="https://img.shields.io/badge/langurage-JavaScript-brightgreen?style=flat&color=blue">
     </a>
   </p>
@@ -22,35 +22,35 @@
 
 ## Introduction
 
-[Bob](https://bobtranslate.com/) plugin based on [Anthropic Complete API]([Anthropic Complete API](https://console.anthropic.com/docs/api/reference)). Has translation and retouching functions.
+[Bob](https://bobtranslate.com/) plugin based on the [OpenAI API](https://platform.openai.com/docs/api-reference/introduction). It provides translation and polishing features, and supports custom base URLs, models, API keys, and prompts.
 
 ### Polishing
 
-You can use the Claude API to polish and syntactically modify sentences, you just need to set the target language to be the same as the source language.
+You can use the OpenAI API to polish and syntactically modify sentences by setting the target language to be the same as the source language.
 
 ### Language Model
 
-[Model Comparison in official website](https://docs.anthropic.com/en/docs/about-claude/models#model-comparison)
-* `Claude 3 Haiku` (default): Fastest and most compact model for near-instant responsiveness
-* `Claude 3 Sonnet`: Balance of intelligence and speed
-* `Claude 3 Opus`: Powerful model for highly complex tasks
-* `Claude 3.5 Sonnet`: Most intelligent model
+[Model overview](https://platform.openai.com/docs/models)
+* `GPT-4o mini` (default): Cost-efficient general purpose model
+* `GPT-4o`: Flagship model for high quality results
+* `GPT-4.1 / GPT-4.1 mini`: Latest multimodal models
+* `o3-mini`: Advanced reasoning model
 
 ## Usage
 
 
 1. Install [Bob](https://bobtranslate.com/guide/#%E5%AE%89%E8%A3%85) (version >= 0.50), a translation and OCR software for the macOS platform
 
-2. Download this plugin: [claude-translator.bobplugin](https://github.com/jtsang4/bob-plugin-claude-translator/releases/latest)
+2. Download this plugin: [openai-translator.bobplugin](https://github.com/jtsang4/bob-plugin-openaiapi/releases/latest)
 
 3. Install this plugin
 
-4. Get your access key from [Claude](https://console.anthropic.com/account/keys)
+4. Get your access key from [OpenAI](https://platform.openai.com/api-keys)
 
-5. Enter the API KEY in Bob Preferences > Services > This plugin configuration interface's API KEY input box
+5. Enter the API KEY in Bob Preferences > Services > This plugin configuration interface's API KEY input box. You can configure multiple keys, base URLs, models, and custom prompts.
 
 6. (Optional) Install [PopClip](https://bobtranslate.com/guide/integration/popclip.html) to achieve the floating icon appearing near the mouse after selecting words
 
 ## Thanks
 
-This repository is based on the excellent [bob-plugin-openai-translator](https://github.com/yetone/bob-plugin-openai-translator) from [yetone](https://github.com/yetone) This is an adaptation of the Claude API based on the source code, thanks to the excellent contribution of the original author.
+This repository is again adapted from the excellent [bob-plugin-openai-translator](https://github.com/yetone/bob-plugin-openai-translator) by [yetone](https://github.com/yetone). Many thanks to the original author for the outstanding contribution.

--- a/src/info.json
+++ b/src/info.json
@@ -1,13 +1,13 @@
 {
-  "identifier": "jtsang.claude.translator",
-  "version": "0.6.0",
+  "identifier": "openai.translator",
+  "version": "0.7.0",
   "category": "translate",
-  "name": "Claude Translator",
-  "summary": "Claude powered translator",
+  "name": "OpenAI Translator",
+  "summary": "OpenAI powered translator",
   "icon": "",
   "author": "jtsang <wtzeng1@gmail.com>",
-  "homepage": "https://github.com/jtsang4/bob-plugin-claude-translator",
-  "appcast": "https://raw.githubusercontent.com/jtsang4/bob-plugin-claude-translator/main/appcast.json",
+  "homepage": "https://github.com/jtsang4/bob-plugin-openaiapi",
+  "appcast": "https://raw.githubusercontent.com/jtsang4/bob-plugin-openaiapi/main/appcast.json",
   "minBobVersion": "1.8.0",
   "options": [
     {
@@ -25,36 +25,13 @@
       "identifier": "model",
       "type": "menu",
       "title": "模型",
-      "defaultValue": "claude-3-haiku-20240307",
+      "defaultValue": "gpt-4o-mini",
       "menuValues": [
-        {
-          "title": "Claude 3 Haiku",
-          "value": "claude-3-haiku-20240307"
-        },
-        {
-          "title": "claude 3.5 Haiku",
-          "value": "claude-3-5-haiku-20241022"
-        },
-        {
-          "title": "Claude 3 Opus",
-          "value": "claude-3-opus-20240229"
-        },
-        {
-          "title": "Claude 3 Sonnet",
-          "value": "claude-3-sonnet-20240229"
-        },
-        {
-          "title": "Claude 3.5 Sonnet 2024-06-20",
-          "value": "claude-3-5-sonnet-20240620"
-        },
-        {
-          "title": "Claude 3.5 Sonnet",
-          "value": "claude-3-5-sonnet-20241022"
-        },
-        {
-          "title": "Claude 2.1(模型过时，不推荐使用)",
-          "value": "claude-2.1"
-        }
+        { "title": "GPT-4o mini", "value": "gpt-4o-mini" },
+        { "title": "GPT-4o", "value": "gpt-4o" },
+        { "title": "GPT-4.1", "value": "gpt-4.1" },
+        { "title": "GPT-4.1 mini", "value": "gpt-4.1-mini" },
+        { "title": "o3-mini", "value": "o3-mini" }
       ]
     },
     {
@@ -103,10 +80,10 @@
       "identifier": "apiUrl",
       "type": "text",
       "title": "自定义 API Base URL",
-      "desc": "如果您的网络环境需要代理才能访问 Claude API, 可在这里修改为反代 API 的地址",
+      "desc": "如果您的网络环境需要代理才能访问 OpenAI API, 可在这里修改为反代 API 的地址",
       "textConfig": {
         "type": "visible",
-        "placeholderText": "https://api.anthropic.com"
+        "placeholderText": "https://api.openai.com"
       }
     },
     {
@@ -116,7 +93,7 @@
       "desc": "发送请求的Path",
       "textConfig": {
         "type": "visible",
-        "placeholderText": "/v1/messages"
+        "placeholderText": "/v1/chat/completions"
       }
     },
     {


### PR DESCRIPTION
## Summary
- replace Anthropic integration with OpenAI chat completions including configurable base URL, key rotation, and streaming handling
- expose OpenAI-focused defaults in plugin metadata and documentation, including updated model list and configuration guidance

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db47f17ba483238b660d4f24bcbad5