### PR TITLE
Allow configuring base_url and manual model selection

### DIFF
--- a/src/info.json
+++ b/src/info.json
@@ -23,16 +23,14 @@
     },
     {
       "identifier": "model",
-      "type": "menu",
+      "type": "text",
       "title": "模型",
       "defaultValue": "gpt-4o-mini",
-      "menuValues": [
-        { "title": "GPT-4o mini", "value": "gpt-4o-mini" },
-        { "title": "GPT-4o", "value": "gpt-4o" },
-        { "title": "GPT-4.1", "value": "gpt-4.1" },
-        { "title": "GPT-4.1 mini", "value": "gpt-4.1-mini" },
-        { "title": "o3-mini", "value": "o3-mini" }
-      ]
+      "desc": "可选项。填写任意支持的模型名称，例如 gpt-4o-mini、gpt-4.1、o3-mini 等。",
+      "textConfig": {
+        "type": "visible",
+        "placeholderText": "例如：gpt-4o-mini"
+      }
     },
     {
       "identifier": "temperature",
@@ -77,7 +75,7 @@
       }
     },
     {
-      "identifier": "apiUrl",
+      "identifier": "base_url",
       "type": "text",
       "title": "自定义 API Base URL",
       "desc": "如果您的网络环境需要代理才能访问 OpenAI API, 可在这里修改为反代 API 的地址",

--- a/src/main.js
+++ b/src/main.js
@@ -257,7 +257,12 @@ function translate(query) {
       });
   }
 
-  const {model, apiKeys, apiUrl, apiUrlPath} = $option;
+  const apiKeys = $option.apiKeys;
+  const optionModel = typeof $option.model === 'string' ? $option.model.trim() : '';
+  const resolvedModel = optionModel || 'gpt-4o-mini';
+  const apiUrl = typeof $option.apiUrl === 'string' ? $option.apiUrl.trim() : '';
+  const baseUrlOption = typeof $option.base_url === 'string' ? $option.base_url.trim() : '';
+  const apiUrlPath = typeof $option.apiUrlPath === 'string' ? $option.apiUrlPath.trim() : '';
 
   if (!apiKeys || typeof apiKeys !== 'string') {
     return query.onCompletion({
@@ -285,12 +290,12 @@ function translate(query) {
   const apiKey =
     apiKeySelection[Math.floor(Math.random() * apiKeySelection.length)];
 
-  const baseUrl = apiUrl || "https://api.openai.com";
+  const baseUrl = baseUrlOption || apiUrl || "https://api.openai.com";
   const urlPath = apiUrlPath || "/v1/chat/completions";
 
   const header = buildHeader(apiKey);
   const canStreamRequest = typeof $http !== 'undefined' && typeof $http.streamRequest === 'function' && typeof query.onStream === 'function';
-  const body = buildRequestBody(model, query, canStreamRequest);
+  const body = buildRequestBody(resolvedModel, query, canStreamRequest);
 
   (async () => {
     if (canStreamRequest) {


### PR DESCRIPTION
## Summary
- allow the plugin to read a `base_url` option while still falling back to the legacy API base URL setting
- switch the model setting to a free-form text field so users can enter any model name they need

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68db5363f3f883239f2482d61fe43f78